### PR TITLE
ES-5496 Fix double json encoding bug

### DIFF
--- a/src/Concerns/HasDrafts.php
+++ b/src/Concerns/HasDrafts.php
@@ -209,6 +209,17 @@ trait HasDrafts
         Arr::forget($oldAttributes, [$this->getKeyName(), 'uuid']);
         Arr::forget($newAttributes, [$this->getKeyName(), 'uuid']);
 
+        // This logic has been added to prevent casted attributes that are json castable from double encoding on draft publish
+        $jsonCastableTypes = ['array', 'json', 'object', 'collection', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object'];
+        $castedAttributes = $this->getCasts();
+        foreach ($castedAttributes as $attribute=>$type) {
+            if (in_array($type, (array) $jsonCastableTypes, true)) {
+                $newAttributes[$attribute] = json_decode($newAttributes[$attribute]);
+                $oldAttributes[$attribute] = json_decode($oldAttributes[$attribute]);
+            }
+        }
+        // end 
+
         $published->forceFill($newAttributes);
         $this->forceFill($oldAttributes);
 


### PR DESCRIPTION
Please follow our [PR Guidelines](https://technologyadvice.atlassian.net/wiki/spaces/EN/pages/962560174/PR+Documentation+Review+Guidelines) for submitting or reviewing a PR

NOTE: If an assignee was automatically added to this PR, the user opening the PR must get both Reviewer and Assignee approval before merging.

### Description
When a product (using laravel-drafts) was published, the 'pricing_model' (casted to an array) was being incorrectly json encoded for a second time. This PR checks for any attributes casted to a json type, and decodes them before calling forceFill(), which json encodes.

### Related issue(s)
https://technologyadvice.atlassian.net/jira/servicedesk/projects/ES/queues/issue/ES-5496

### Related PR(s)

### How to test / repro

1. Copy/paste changes directly to products/vendor/technologyadvice/laravel-drafts/src/Concerns/HasDrafts.php
2. Go to any product edit page, check a pricing model and save
3. Uncheck the pricing model and save
4. impersonate a user and make any change. Save product
5. Stop impersonating, go to product review and approve your change
6. Go back to product edit page and view change history. Verify pricing_model is not present (for the impersonated user's change, the one made initially will be there)
7. Use Query 1 to query for product (uuid in product edit page url)
8. Verify the pricing_model is not a string

### Screenshots

### Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have tested this code
- [ ] If this is a bugfix, I've added testing to check this in the future
- [ ] I have updated the Readme
- [ ] I have added appropriate logging at the correct levels
